### PR TITLE
Improve field test coverage

### DIFF
--- a/core/test/RunCM31Tests.hs
+++ b/core/test/RunCM31Tests.hs
@@ -5,7 +5,14 @@
 -- | QuickCheck tests for Field.CM31, mirroring the original Rust tests.
 module Main (main) where
 
-import Field.CM31 (CM31, mkCM31, unCM31)
+import Field.CM31
+  ( CM31
+  , mkCM31
+  , unCM31
+  , conjugate
+  , norm
+  , square
+  )
 import Field.M31
   ( -- M31       -- Type M31 is not directly used, CM31 uses it internally
     unM31     -- To get Word32 from M31 (used in CM31 tests' Arbitrary instance indirectly, and in intoSlice)
@@ -81,6 +88,26 @@ prop_ops =
          ]
 
 ------------------------------------------------------------------------
+-- 3. Additional property tests
+------------------------------------------------------------------------
+
+prop_conjugate_involution :: CM31 -> Bool
+prop_conjugate_involution x = conjugate (conjugate x) == x
+
+prop_norm_definition :: CM31 -> Bool
+prop_norm_definition x =
+  let (a, b) = unCM31 x
+  in norm x == a * a + b * b
+
+prop_square_definition :: CM31 -> Bool
+prop_square_definition x = square x == x * x
+
+prop_norm_mul_conjugate :: CM31 -> Bool
+prop_norm_mul_conjugate x =
+  let expected = mkCM31 (unM31 (norm x)) 0
+  in x * conjugate x == expected
+
+------------------------------------------------------------------------
 -- 3. intoSlice round‑trip
 ------------------------------------------------------------------------
 prop_intoSlice :: Property
@@ -101,4 +128,9 @@ main = do
   putStrLn "Running CM31 QuickCheck suite..."
   quickCheck prop_inverse
   quickCheck prop_ops
+  quickCheck prop_conjugate_involution
+  quickCheck prop_norm_definition
+  quickCheck prop_square_definition
+  quickCheck prop_norm_mul_conjugate
   quickCheck prop_intoSlice
+

--- a/core/test/RunQM31Tests.hs
+++ b/core/test/RunQM31Tests.hs
@@ -4,20 +4,42 @@
 
 module Main (main) where
 
-import Field.QM31 (QM31, mkQM31, unQM31)
-import Field.CM31 (CM31, unCM31)
+import qualified Field.QM31 as Q
+  ( QM31
+  , mkQM31
+  , unQM31
+  , fromPartialEvals
+  , mulCM31
+  , conjugate
+  , norm
+  , square
+  )
+import qualified Field.CM31 as C
+  ( CM31
+  , mkCM31
+  , unCM31
+  , conjugate
+  , norm
+  , square
+  )
 import Field.M31  (M31, modulus, unM31)
 import Test.QuickCheck
 import Data.Word (Word8, Word32)
 import Data.Bits ((.|.), shiftL, shiftR)
+import Control.Exception (ErrorCall(..), evaluate, try)
+import qualified Test.QuickCheck.Monadic as QCM
 
 -- | Random QM31 from raw Word32s.
-instance Arbitrary QM31 where
-  arbitrary = mkQM31
+instance Arbitrary Q.QM31 where
+  arbitrary = Q.mkQM31
     <$> choose (0, modulus - 1)
     <*> choose (0, modulus - 1)
     <*> choose (0, modulus - 1)
     <*> choose (0, modulus - 1)
+
+instance Arbitrary C.CM31 where
+  arbitrary = C.mkCM31 <$> choose (0, modulus - 1)
+                       <*> choose (0, modulus - 1)
 
 -- | Little-endian bytes to Word32.
 bytesToWord32LE :: Word8 -> Word8 -> Word8 -> Word8 -> Word32
@@ -28,11 +50,11 @@ bytesToWord32LE b0 b1 b2 b3 =
     .|. (fromIntegral b3 `shiftL` 24)
 
 -- | Serialize a list of QM31 into bytes (16 bytes each).
-intoSlice :: [QM31] -> [Word8]
+intoSlice :: [Q.QM31] -> [Word8]
 intoSlice = concatMap $ \qm ->
-  let (cm_part1, cm_part2) = unQM31 qm
-      (m31_a0, m31_a1)   = unCM31 cm_part1
-      (m31_a2, m31_a3)   = unCM31 cm_part2
+  let (cm_part1, cm_part2) = Q.unQM31 qm
+      (m31_a0, m31_a1)   = C.unCM31 cm_part1
+      (m31_a2, m31_a3)   = C.unCM31 cm_part2
       w32_a0 = unM31 m31_a0
       w32_a1 = unM31 m31_a1
       w32_a2 = unM31 m31_a2
@@ -48,7 +70,7 @@ intoSlice = concatMap $ \qm ->
 ------------------------------------------------------------------------
 prop_inverse :: Property
 prop_inverse =
-  let qm    = mkQM31 1 2 3 4
+  let qm    = Q.mkQM31 1 2 3 4
       qmInv = recip qm
   in qm * qmInv === fromInteger 1
 
@@ -57,20 +79,57 @@ prop_inverse =
 ------------------------------------------------------------------------
 prop_ops :: Bool
 prop_ops =
-  let qm0       = mkQM31 1 2 3 4
-      qm1       = mkQM31 4 5 6 7
-      m         = fromInteger 8 :: QM31
-      qm0_x_qm1 = mkQM31 (modulus - 71) 93 (modulus - 16) 50
-  in and [ qm0 + qm1 == mkQM31 5 7 9 11
+  let qm0       = Q.mkQM31 1 2 3 4
+      qm1       = Q.mkQM31 4 5 6 7
+      m         = fromInteger 8 :: Q.QM31
+      qm0_x_qm1 = Q.mkQM31 (modulus - 71) 93 (modulus - 16) 50
+  in and [ qm0 + qm1 == Q.mkQM31 5 7 9 11
          , qm1 + m     == qm1 + m
          , qm0 * qm1   == qm0_x_qm1
          , qm1 * m     == qm1 * m
-         , negate qm0  == mkQM31 (modulus - 1) (modulus - 2) (modulus - 3) (modulus - 4)
-         , qm0 - qm1   == mkQM31 (modulus - 3) (modulus - 3) (modulus - 3) (modulus - 3)
+         , negate qm0  == Q.mkQM31 (modulus - 1) (modulus - 2) (modulus - 3) (modulus - 4)
+         , qm0 - qm1   == Q.mkQM31 (modulus - 3) (modulus - 3) (modulus - 3) (modulus - 3)
          , qm1 - m     == qm1 - m
-         , qm0_x_qm1 / qm1 == mkQM31 1 2 3 4
+         , qm0_x_qm1 / qm1 == Q.mkQM31 1 2 3 4
          , qm1 / m     == qm1 / m
          ]
+
+------------------------------------------------------------------------
+-- 3. Additional property tests
+------------------------------------------------------------------------
+
+prop_conjugate_involution :: Q.QM31 -> Bool
+prop_conjugate_involution x = Q.conjugate (Q.conjugate x) == x
+
+prop_norm_definition :: Q.QM31 -> Bool
+prop_norm_definition x =
+  let (realPart, imagPart) = Q.unQM31 (x * Q.conjugate x)
+  in imagPart == C.mkCM31 0 0 && realPart == Q.norm x
+
+prop_square_definition :: Q.QM31 -> Bool
+prop_square_definition x = Q.square x == x * x
+
+prop_mulCM31_definition :: Q.QM31 -> C.CM31 -> Bool
+prop_mulCM31_definition x c =
+  let (a,b) = Q.unQM31 x
+      (rA,rB) = Q.unQM31 (Q.mulCM31 x c)
+  in rA == a * c && rB == b * c
+
+prop_fromPartialEvals_definition :: Q.QM31 -> Q.QM31 -> Q.QM31 -> Q.QM31 -> Bool
+prop_fromPartialEvals_definition e0 e1 e2 e3 =
+  Q.fromPartialEvals [e0,e1,e2,e3]
+    == e0 + e1 * Q.mkQM31 0 0 1 0
+         + e2 * Q.mkQM31 2 1 0 0
+         + e3 * Q.mkQM31 0 0 2 1
+
+prop_fromPartialEvals_error :: [Q.QM31] -> Property
+prop_fromPartialEvals_error xs =
+  length xs /= 4 ==> QCM.monadicIO $ do
+    result <- QCM.run $ try (evaluate (Q.fromPartialEvals xs))
+    case result of
+      Left (ErrorCall msg) ->
+        QCM.assert (msg == "Field.QM31.fromPartialEvals: need exactly 4 elements")
+      Right _ -> QCM.stop (counterexample "expected exception" False)
 
 ------------------------------------------------------------------------
 -- 3. intoSlice round-trip
@@ -79,7 +138,7 @@ prop_intoSlice :: Property
 prop_intoSlice = forAll (vectorOf 100 arbitrary) $ \xs ->
   let bs = intoSlice xs
   in conjoin [ xs !! i
-               === mkQM31
+               === Q.mkQM31
                      (bytesToWord32LE (bs !! (16*i + 0)) (bs !! (16*i + 1)) (bs !! (16*i + 2)) (bs !! (16*i + 3)))
                      (bytesToWord32LE (bs !! (16*i + 4)) (bs !! (16*i + 5)) (bs !! (16*i + 6)) (bs !! (16*i + 7)))
                      (bytesToWord32LE (bs !! (16*i + 8)) (bs !! (16*i + 9)) (bs !! (16*i + 10)) (bs !! (16*i + 11)))
@@ -95,4 +154,10 @@ main = do
   putStrLn "Running QM31 QuickCheck suite..."
   quickCheck prop_inverse
   quickCheck prop_ops
+  quickCheck prop_conjugate_involution
+  quickCheck prop_norm_definition
+  quickCheck prop_square_definition
+  quickCheck prop_mulCM31_definition
+  quickCheck prop_fromPartialEvals_definition
+  quickCheck prop_fromPartialEvals_error
   quickCheck prop_intoSlice


### PR DESCRIPTION
## Summary
- expand CM31 property tests
- expand QM31 property tests with conjugation, norms, and partial evals

## Testing
- `cabal test all --test-show-details=streaming` *(fails: `cabal: command not found`)*